### PR TITLE
SIMPLY-3802: Do page numbers reset at the start of a chapter or not?

### DIFF
--- a/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2BookMetadata.kt
+++ b/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2BookMetadata.kt
@@ -22,7 +22,13 @@ data class SR2BookMetadata(
    * The chapters of the book in reading order.
    */
 
-  val readingOrder: List<SR2BookChapter>
+  val readingOrder: List<SR2BookChapter>,
+
+  /**
+   * The number of positions in the book
+   */
+
+  val positionCount: Int
 ) {
 
   init {

--- a/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Event.kt
+++ b/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Event.kt
@@ -51,8 +51,7 @@ sealed class SR2Event {
     val chapterHref: String,
     val chapterTitle: String?,
     val chapterProgress: Double,
-    val currentPage: Int,
-    val pageCount: Int,
+    val currentPosition: Int,
     val bookProgress: Double
   ) : SR2Event() {
 

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Books.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Books.kt
@@ -9,12 +9,14 @@ internal object SR2Books {
 
   fun makeMetadata(
     publication: Publication,
-    bookId: String
+    bookId: String,
+    positionCount: Int
   ): SR2BookMetadata {
     return SR2BookMetadata(
       id = bookId,
       title = publication.metadata.title,
-      readingOrder = this.makeReadingOrder(publication)
+      readingOrder = this.makeReadingOrder(publication),
+      positionCount = positionCount
     )
   }
 

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
@@ -48,7 +48,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.annotation.concurrent.GuardedBy
-import kotlin.math.ceil
+import kotlin.math.round
 
 /**
  * The default R2 controller implementation.
@@ -660,9 +660,13 @@ internal class SR2Controller private constructor(
         }
       }
 
-      val chapterPositions = this@SR2Controller.positionsByReadingOrder[currentChapter.chapterIndex]
-      val positionIndex = ceil(chapterProgress * (chapterPositions.size - 1)).toInt()
-      val currentPosition = chapterPositions[positionIndex].locations.position!!
+      val chapterPositions =
+        this@SR2Controller.positionsByReadingOrder[currentChapter.chapterIndex]
+      val positionIndex =
+        round(chapterProgress * chapterPositions.size).toInt()
+          .coerceAtMost(chapterPositions.size - 1)
+      val currentPosition =
+        chapterPositions[positionIndex].locations.position!!
 
       this@SR2Controller.eventSubject.onNext(
         SR2ReadingPositionChanged(

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -234,7 +234,8 @@ class SR2ReaderFragment private constructor(
     val context = this.context ?: return
     this.logger.debug("chapterTitle=${event.chapterTitle}")
     this.progressView.apply { this.max = 100; this.progress = event.bookProgressPercent }
-    this.positionPageView.text = context.getString(R.string.progress_page, event.currentPage, event.pageCount)
+    val positionCount = this.controller!!.bookMetadata.positionCount
+    this.positionPageView.text = context.getString(R.string.progress_page, event.currentPosition, positionCount)
     this.positionTitleView.text = event.chapterTitle
     this.positionPercentView.text = this.getString(R.string.progress_percent, event.bookProgressPercent)
     this.reconfigureBookmarkMenuItem(event.locator)


### PR DESCRIPTION
**What does this do?**
This modifies the way page numbers are computed.

Use Readium byte-based positions to compute page numbers. They don't start from 0 at the beginning of a new chapter any more, and hardly depend on screen and font sizes.

**Why are we doing this?**
[SIMPLY-3802: Do page numbers reset at the start of a chapter or not?](https://jira.nypl.org/browse/SIMPLY-3802)

**Background**
Filing this in the SimplyE project because it's not clear which mobile product needs to change.

When you read a book on SimplyE iOS, the number referred to as a "page number" has some relationship to the length of the book as a whole. Let's say "Page 1 of 347." You start at page 1, and the page number gradually goes up until it gets to page 347, which is the end of the book.

There are all sorts of inconsistencies and weird cases when it comes to this notion of "page number", which are covered in other issues like https://jira.nypl.org/browse/IOS-210. The point I want to convey here is that on iOS, the implementation numbers "pages" (whatever they are) from the beginning of the book to the end, the way a print book does.

On Android, the number referred to as a "page number" is related to the length of a chapter. Where iOS would start you out on "Page 1 of 347", Android might start you out in the same book with "Page 1 of 4". Paging through from "Page 4 of 4" to the next chapter, you would then see (let's say) "Page 1 of 7", at the same point in the book which on iOS would be labelled "Page 5 of 347". 

I don't know which of these implementations is right – each has its advantages – and we don't need exactly the same definition of "page number" across platforms, but we should at least standardize on whether "page number" resets at the start of a chapter.
