### PR TITLE
OE-168 - TOC Does not display for certain books

### DIFF
--- a/build_libraries.gradle
+++ b/build_libraries.gradle
@@ -40,6 +40,7 @@ ext.libraries = [
   androidx_app_compat         : "androidx.appcompat:appcompat:${versions.androidx_app_compat}",
   androidx_constraint_layout  : "androidx.constraintlayout:constraintlayout:${versions.androidx_constraint_layout}",
   androidx_core               : "androidx.core:core:${versions.androidx_core}",
+  androidx_core_ktx           : "androidx.core:core-ktx:${versions.androidx_core}",
   androidx_fragment_testing   : "androidx.fragment:fragment-testing:${versions.androidx_fragment_testing}",
   androidx_lifecycle          : "androidx.lifecycle:lifecycle-extensions:${versions.androidx_lifecycle}",
   androidx_lifecycle_viewmodel: "androidx.lifecycle:lifecycle-viewmodel:${versions.androidx_lifecycle_viewmodel}",

--- a/org.librarysimplified.r2.views/build.gradle
+++ b/org.librarysimplified.r2.views/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   implementation libraries.androidx_app_compat
   implementation libraries.androidx_constraint_layout
-  implementation libraries.androidx_core
+  implementation libraries.androidx_core_ktx
   implementation libraries.androidx_lifecycle
   implementation libraries.androidx_lifecycle_viewmodel
   implementation libraries.androidx_view_pager2

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2DiffUtils.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2DiffUtils.kt
@@ -2,7 +2,6 @@ package org.librarysimplified.r2.views.internal
 
 import androidx.recyclerview.widget.DiffUtil
 import org.librarysimplified.r2.api.SR2Bookmark
-import org.librarysimplified.r2.api.SR2TOCEntry
 
 internal object SR2DiffUtils {
 
@@ -21,17 +20,17 @@ internal object SR2DiffUtils {
         oldItem == newItem
     }
 
-  val tocEntryCallback: DiffUtil.ItemCallback<SR2TOCEntry> =
-    object : DiffUtil.ItemCallback<SR2TOCEntry>() {
+  val tocEntryCallback: DiffUtil.ItemCallback<SR2TOCChapterItem> =
+    object : DiffUtil.ItemCallback<SR2TOCChapterItem>() {
       override fun areItemsTheSame(
-        oldItem: SR2TOCEntry,
-        newItem: SR2TOCEntry
+        oldItem: SR2TOCChapterItem,
+        newItem: SR2TOCChapterItem
       ): Boolean =
         oldItem == newItem
 
       override fun areContentsTheSame(
-        oldItem: SR2TOCEntry,
-        newItem: SR2TOCEntry
+        oldItem: SR2TOCChapterItem,
+        newItem: SR2TOCChapterItem
       ): Boolean =
         oldItem == newItem
     }

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChapterAdapter.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChapterAdapter.kt
@@ -8,15 +8,14 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import org.librarysimplified.r2.api.SR2TOCEntry
 import org.librarysimplified.r2.views.R
 import org.librarysimplified.r2.views.internal.SR2DiffUtils.tocEntryCallback
 import org.librarysimplified.r2.views.internal.SR2TOCChapterAdapter.SR2TOCChapterViewHolder
 
 internal class SR2TOCChapterAdapter(
   private val resources: Resources,
-  private val onTOCEntrySelected: (SR2TOCEntry) -> Unit
-) : ListAdapter<SR2TOCEntry, SR2TOCChapterViewHolder>(tocEntryCallback) {
+  private val onTOCEntrySelected: (SR2TOCChapterItem) -> Unit
+) : ListAdapter<SR2TOCChapterItem, SR2TOCChapterViewHolder>(tocEntryCallback) {
 
   class SR2TOCChapterViewHolder(
     val rootView: View
@@ -55,14 +54,14 @@ internal class SR2TOCChapterAdapter(
     val layoutParams = holder.chapterTitleText.layoutParams as ViewGroup.MarginLayoutParams
     layoutParams.marginStart = (chapter.depth + 1) * this.dpToPixels(24.0f)
     holder.chapterTitleText.layoutParams = layoutParams
-    holder.chapterTitleText.text = chapter.node.title
+    holder.chapterTitleText.text = chapter.title
   }
 
   private fun dpToPixels(dp: Float): Int {
     return Math.round(dp * (this.resources.displayMetrics.densityDpi / 160f))
   }
 
-  fun setTableOfContentsEntries(entriesNow: List<SR2TOCEntry>) {
+  fun setTableOfContentsEntries(entriesNow: List<SR2TOCChapterItem>) {
     this.submitList(entriesNow)
   }
 }

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChapterItem.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChapterItem.kt
@@ -1,0 +1,22 @@
+package org.librarysimplified.r2.views.internal
+
+import org.librarysimplified.r2.api.SR2NavigationNode
+import org.librarysimplified.r2.api.SR2TOCEntry
+
+internal data class SR2TOCChapterItem(
+  val title: String,
+  val href: String,
+  val depth: Int
+)
+
+internal fun SR2TOCEntry.toChapterItem() = SR2TOCChapterItem(
+  this.node.title,
+  this.node.navigationPoint.locator.chapterHref,
+  this.depth
+)
+
+internal fun SR2NavigationNode.SR2NavigationReadingOrderNode.toChapterItem() = SR2TOCChapterItem(
+  this.title,
+  this.navigationPoint.locator.chapterHref,
+  0
+)

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChaptersFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChaptersFragment.kt
@@ -4,9 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
 import org.librarysimplified.r2.api.SR2Command
@@ -57,7 +58,6 @@ internal class SR2TOCChaptersFragment private constructor(
     recyclerView.adapter = this.chapterAdapter
     recyclerView.setHasFixedSize(true)
     recyclerView.setItemViewCacheSize(32)
-    recyclerView.layoutManager = LinearLayoutManager(this.context)
     (recyclerView.itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
     return layout
   }
@@ -72,7 +72,12 @@ internal class SR2TOCChaptersFragment private constructor(
         .get(SR2ReaderViewModel::class.java)
 
     this.controller = this.readerModel.get()!!
-    this.chapterAdapter.setTableOfContentsEntries(getChapters())
+    val chapters = getChapters()
+    view?.apply {
+      findViewById<View>(R.id.tocChaptersError)?.isVisible = chapters.isEmpty()
+      findViewById<RecyclerView>(R.id.tocChaptersList)?.isGone = chapters.isEmpty()
+    }
+    this.chapterAdapter.setTableOfContentsEntries(chapters)
   }
 
   private fun onTOCEntrySelected(entry: SR2TOCChapterItem) {

--- a/org.librarysimplified.r2.views/src/main/res/layout/sr2_toc_chapters.xml
+++ b/org.librarysimplified.r2.views/src/main/res/layout/sr2_toc_chapters.xml
@@ -1,15 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
-  android:background="#ffffff"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:background="#ffffff">
 
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/tocChaptersList"
     android:layout_width="0dp"
     android:layout_height="0dp"
+    android:orientation="vertical"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:listitem="@layout/sr2_toc_chapter_item" />
+
+  <TextView
+    android:id="@+id/tocChaptersError"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/tocError"
+    android:textSize="18sp"
+    android:visibility="gone"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
+++ b/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
@@ -22,6 +22,7 @@
   <string name="tocBookmarkDeleteMessage">Are you sure you want to delete this bookmark?</string>
   <string name="tocBookmarks">Bookmarks</string>
   <string name="tocTitle">Table Of Contents</string>
+  <string name="tocError">No entries available.</string>
   <string name="tocAccessChapter">Open Chapter %1$d: %2$s</string>
 
   <string name="settingsAccessibilitySetSans">Set book font to sans-serif.</string>


### PR DESCRIPTION
What does this do?
- Uses a book's reading order entries if there are no TOC entries available
- Added an error message if book doesn't have TOC entries or reading order entries

Why are we doing this?
[OE-168 ](https://jira.nypl.org/browse/OE-168)

Background
On the book _Blood Will Tell_ by April Henry, when navigating to the table of contents the app will display a blank screen.