### PR TITLE
Fix URL's fragment handling

### DIFF
--- a/org.librarysimplified.r2.vanilla/src/main/assets/readium/scripts/utils.js
+++ b/org.librarysimplified.r2.vanilla/src/main/assets/readium/scripts/utils.js
@@ -155,8 +155,19 @@ var readium = (function() {
             return;
         }
         console.log("scrolling to element " + element + " with id " + id)
-        element.scrollIntoView({inline: "center"});
-        snapCurrentOffset();
+        var rect = element.getBoundingClientRect();
+        scrollToRect(rect);
+    }
+
+    function scrollToRect(rect) {
+      if (isScrollModeEnabled()) {
+        document.scrollingElement.scrollTop =
+          rect.top + window.scrollY - window.innerHeight / 2;
+      } else {
+        document.scrollingElement.scrollLeft = snapOffset(
+          rect.left + window.scrollX
+        );
+      }
     }
 
     // Position must be in the range [0 - 1], 0-100%.


### PR DESCRIPTION
_One Amazing Thing_ (Open Ebooks) is using fragments in the table of contents. Clicking on some toc entry used to get patrons into the middle of the chapter. This fix enables to go to the beginning instead.