### PR TITLE
Properly debounce clicks in TOC

### DIFF
--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2DebouncingOnClickListener.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2DebouncingOnClickListener.kt
@@ -1,0 +1,33 @@
+package org.librarysimplified.r2.views.internal
+
+import android.view.View
+
+/**
+ * Register a callback to be invoked when this view is clicked,
+ * preventing new clicks for the given time in milliseconds.
+ */
+
+internal fun View.setOnClickListener(interval: Long, onClick: (View) -> Unit) {
+  setOnClickListener(
+    SR2DebouncingOnClickListener(interval, onClick)
+  )
+}
+
+private class SR2DebouncingOnClickListener(
+  private val interval: Long,
+  private val onClick: (View) -> Unit
+) : View.OnClickListener {
+
+  private var isEnabled = true
+
+  override fun onClick(view: View) {
+    if (isEnabled) {
+      isEnabled = false
+      onClick.invoke(view)
+      view.postDelayed(
+        { isEnabled = true },
+        interval
+      )
+    }
+  }
+}

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOC.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOC.kt
@@ -3,11 +3,16 @@ package org.librarysimplified.r2.views.internal
 internal object SR2TOC {
 
   /**
-   * The delay applied after selecting a TOC item. This purely exists to allow the
-   * selection animation time to complete before the TOC fragment is closed.
+   * The delay applied before closing the TOC after an item has been selected. This purely exists
+   * to allow the selection animation time to complete before the TOC fragment is closed.
    */
 
-  fun tocSelectionDelay(): Long {
-    return 300L
-  }
+  const val closeTocDelay: Long = 300L
+
+  /**
+   * The delay applied before enabling clicks on TOC items again. This purely exists to prevent
+   * click handlers to be executed multiple times.
+   */
+
+  const val reenableClickDelay: Long = 1000L
 }

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOC.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOC.kt
@@ -11,7 +11,7 @@ internal object SR2TOC {
 
   /**
    * The delay applied before enabling clicks on TOC items again. This purely exists to prevent
-   * click handlers to be executed multiple times.
+   * click handlers from being executed multiple times.
    */
 
   const val reenableClickDelay: Long = 1000L

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
@@ -65,8 +65,7 @@ internal class SR2TOCBookmarkViewHolder(
       }
     }
 
-    this.rootView.setOnClickListener {
-      this.rootView.setOnClickListener(null)
+    this.rootView.setOnClickListener(SR2TOC.reenableClickDelay) {
       onBookmarkSelected.invoke(bookmark)
     }
     this.bookmarkTitleText.text = bookmark.title

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarksFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarksFragment.kt
@@ -107,7 +107,7 @@ internal class SR2TOCBookmarksFragment private constructor(
     this.viewModel.openBookmark(bookmark)
     SR2UIThreadService.runOnUIThreadUnsafeDelayed(
       this.viewModel::closeToc,
-      SR2TOC.tocSelectionDelay()
+      SR2TOC.closeTocDelay
     )
   }
 

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChapterAdapter.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChapterAdapter.kt
@@ -43,8 +43,7 @@ internal class SR2TOCChapterAdapter(
     position: Int
   ) {
     val chapter = this.getItem(position)
-    holder.rootView.setOnClickListener {
-      holder.rootView.setOnClickListener(null)
+    holder.rootView.setOnClickListener(SR2TOC.reenableClickDelay) {
       this.onTOCEntrySelected.invoke(chapter)
     }
 

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChaptersFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCChaptersFragment.kt
@@ -99,7 +99,7 @@ internal class SR2TOCChaptersFragment private constructor(
     this.viewModel.openTocEntry(entry)
     SR2UIThreadService.runOnUIThreadUnsafeDelayed(
       this.viewModel::closeToc,
-      SR2TOC.tocSelectionDelay()
+      SR2TOC.closeTocDelay
     )
   }
 


### PR DESCRIPTION
Multiple clicks used to be prevented in a dangerous way which probably worked... at some time. Now the table of contents is created only once at startup, so definitively disabling click handlers prevented from selecting the same TOC item multiple times in a unique reading session.